### PR TITLE
Define POS-based toy CFG

### DIFF
--- a/grammars/toy.cfg
+++ b/grammars/toy.cfg
@@ -1,50 +1,53 @@
-S  -> NP VP .
-PP -> IN NP
-NP -> DT Noun | NP PP
-VP -> Verb NP | VP PP
-Verb -> VB | VBD | VBG | VBN | VBP | VBZ
-Noun -> NN | NNP | NNPS | NNS
+% start S
 
+S -> NP VP Punct
+S -> NP VP            # allow sentences without trailing punctuation (optional)
 
-$ -> '$'
-, -> ','
--LRB- -> '-LRB-'
--RRB- -> '-RRB-'
-. -> '.'
-: -> ':'
-CC -> 'CC'
-CD -> 'CD'
-DT -> 'DT'
-EX -> 'EX'
-FW -> 'FW'
-GW -> 'GW'
-HYPH -> 'HYPH'
-IN -> 'IN'
-JJ -> 'JJ'
-JJR -> 'JJR'
-JJS -> 'JJS'
-MD -> 'MD'
-NN -> 'NN'
-NNP -> 'NNP'
-NNPS -> 'NNPS'
-NNS -> 'NNS'
-PDT -> 'PDT'
-POS -> 'POS'
-PRP -> 'PRP'
-PRP$ -> 'PRP$'
-RB -> 'RB'
-RBR -> 'RBR'
-RBS -> 'RBS'
-RP -> 'RP'
-TO -> 'TO'
-UH -> 'UH'
-VB -> 'VB'
-VBD -> 'VBD'
-VBG -> 'VBG'
-VBN -> 'VBN'
-VBP -> 'VBP'
-VBZ -> 'VBZ'
-WDT -> 'WDT'
-WP -> 'WP'
-WRB -> 'WRB'
-`` -> '``'
+NP -> Det Nbar
+NP -> Nbar
+NP -> Pron
+NP -> NP PP
+
+Nbar -> Adj Nbar
+Nbar -> Noun
+
+VP -> Verb
+VP -> Verb NP
+VP -> Verb NP PP
+VP -> Verb PP
+VP -> Aux VP          # modals/aux + main verb
+VP -> VP PP
+
+PP -> Adp NP
+
+ConjP -> Conj NP
+ConjVP -> Conj VP
+
+# —— Preterminals (map phrases to Penn Treebank POS tags) ——
+
+Det   -> 'DT' | 'PDT' | 'WDT' | 'PRP$' | 'WP$'
+Noun  -> 'NN' | 'NNS' | 'NNP' | 'NNPS'
+Pron  -> 'PRP' | 'WP'
+Adj   -> 'JJ' | 'JJR' | 'JJS'
+Adv   -> 'RB' | 'RBR' | 'RBS' | 'WRB'
+
+Aux   -> 'MD' | 'VBP' | 'VBZ' | 'VBD' | 'VBG' | 'VBN' | 'VB'
+Verb  -> 'VB' | 'VBD' | 'VBG' | 'VBN' | 'VBP' | 'VBZ'
+
+Adp   -> 'IN' | 'TO'
+Conj  -> 'CC'
+
+Punct -> '.'
+
+# —— Optional extras for common structures ——
+# Adverbial modification
+VP -> Adv VP
+NP -> Adv NP
+
+# Coordinations (very light)
+NP -> NP Conj NP
+VP -> VP Conj VP
+
+# Possessives and compounds (lightweight)
+NP -> NP 'POS' Nbar
+Nbar -> Noun Noun


### PR DESCRIPTION
## Summary
- replace the toy CFG with a POS-tag-driven grammar that models NP, VP, PP, coordination, and modifiers
- ensure the grammar uses Penn Treebank POS terminals and optional punctuation handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df74c18cd0832d8f4d8f996a3ed2bd